### PR TITLE
fix: load datasets with repeated items

### DIFF
--- a/finstmt/findata/database.py
+++ b/finstmt/findata/database.py
@@ -74,7 +74,7 @@ class FinDataBase:
                     if item_config.key in data_dict:
                         # Multiple matches for data item.
                         # First see if data is the same, then just skip
-                        if for_lookup[name] == data_dict[item_config.key]:
+                        if (for_lookup[name] == data_dict[item_config.key]).all():
                             continue
                         # Data is not the same, so take the one which is earliest in extract_names
                         current_match_idx = item_config.extract_names.index(name)


### PR DESCRIPTION
Came across this interesting scenario which I think can be fixed.
If the data we are trying to load has a repeated line item (e.g., two SALE items) the code is checking to see if all the data is the same but before this fix, it throws an error.
We could also add some tests for this.
What do you think?