### PR TITLE
fix: Handle calculated items in determining series names. Fixes fcf usage

### DIFF
--- a/finstmt/findata/statementsbase.py
+++ b/finstmt/findata/statementsbase.py
@@ -7,7 +7,11 @@ from tqdm import tqdm
 from finstmt.check import item_series_is_empty
 from finstmt.config_manage.data import _key_pct_of_key
 from finstmt.config_manage.statement import StatementConfigManager
-from finstmt.exc import CouldNotParseException, MixedFrequencyException
+from finstmt.exc import (
+    CouldNotParseException,
+    MixedFrequencyException,
+    NoSuchItemException,
+)
 from finstmt.findata.database import FinDataBase
 from finstmt.forecast.config import ForecastConfig
 from finstmt.forecast.main import Forecast
@@ -64,7 +68,18 @@ class FinStatementsBase:
             if pd.isnull(statement_value):
                 statement_value = 0
             data_dict[date] = statement_value
-        return pd.Series(data_dict, name=self.config.get(item).display_name)
+        item_config: Optional[ItemConfig] = None
+        # TODO: Proper names in series for calculated items
+        #  As nwc is calculated only, it does not have a corresponding config item and so the best
+        #  we can do is use the item key as the name. We can solve this by moving everything to
+        #  config items rather than properties.
+        try:
+            item_config = self.config.get(item)
+        except NoSuchItemException:
+            pass
+        return pd.Series(
+            data_dict, name=item_config.display_name if item_config else item
+        )
 
     def __getitem__(self, item):
         if not isinstance(item, (list, tuple)):

--- a/tests/unit/test_statements.py
+++ b/tests/unit/test_statements.py
@@ -8,3 +8,5 @@ def test_series_name(ro_annual_capiq_stmts: FinancialStatements):
     assert stmts.inventory.name == "Inventory"
     # Check Cash and Cash Equivalents Name is set. This item includes spaces
     assert stmts.cash.name == "Cash and Cash Equivalents"
+    # Check a calculated item name is set
+    assert stmts.nwc.name == "nwc"


### PR DESCRIPTION
## What

Fixes [a bug](https://github.com/nickderobertis/py-finstmt/actions/runs/4231749345/jobs/7350649841) introduced in #87 that caused statements to fail when accessing any calculated item (such as `.fcf`.)

Uses the item's key as the name if the config is not available.